### PR TITLE
Chore: Major version bump due to invenio bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "hatchling.build"
 
 [project]
 name = "oarepo-doi"
-version = "4.0.1"
+version = "5.0.0"
 description = "A module for DOI registration"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.14,<3.15"
 dependencies = [
     "oarepo[rdm,tests]>=14.0.0dev0,<15.0.0",
-    "oarepo-runtime>=4.0.0,<5.0.0",
+    "oarepo-runtime>=5.0.0,<6.0.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Major version bump due to major bump in packages: oarepo-runtime.
